### PR TITLE
fix: harden CI and release workflow security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest
@@ -16,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -43,4 +46,3 @@ jobs:
 
       - name: Audit dependencies
         run: npm audit --audit-level=moderate
-        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,17 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   verify:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22.x
           cache: 'npm'
@@ -38,18 +37,22 @@ jobs:
   publish-release:
     needs: verify
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Determine release tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ steps.tag.outputs.value }}
           name: ${{ steps.tag.outputs.value }}


### PR DESCRIPTION
## Summary
- enforce least-privilege permissions in CI and release workflows
- make dependency audit blocking in CI and pin GitHub Actions to immutable SHAs
- add Dependabot automation for npm and GitHub Actions updates

## Test plan
- [x] npm run lint
- [x] npm audit --audit-level=moderate
- [x] check workflow YAML formatting/syntax

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI and release GitHub Actions permissions and action versions, which can affect build/release execution if misconfigured. Makes `npm audit` failures blocking, potentially increasing CI failures until vulnerabilities are addressed.
> 
> **Overview**
> **Hardens GitHub Actions security and supply-chain controls.** Adds `.github/dependabot.yml` to auto-update `npm` and `github-actions` dependencies weekly.
> 
> CI and release workflows now explicitly set least-privilege `permissions`, pin `actions/checkout`, `actions/setup-node`, and `softprops/action-gh-release` to immutable SHAs, and make `npm audit --audit-level=moderate` blocking (removes `continue-on-error`). Also tweaks release tag determination to pass `inputs.tag` via an env var before writing to `$GITHUB_OUTPUT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf36aedb908a6c04609fd50793a652947956b07b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->