### PR TITLE
feat: add dependency automation on develop (1.7.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'develop'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'develop'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, develop]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches: [develop]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduled-npm-update.yml
+++ b/.github/workflows/scheduled-npm-update.yml
@@ -1,0 +1,52 @@
+name: Scheduled npm update
+
+on:
+  schedule:
+    - cron: '0 6 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: develop
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Update dependencies within ranges
+        run: npm update
+        env:
+          HUSKY: 0
+
+      - name: Verify lint, test, build, audit
+        run: npm run release:check
+        env:
+          HUSKY: 0
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          base: develop
+          branch: chore/npm-update-${{ github.run_id }}
+          title: 'chore(deps): biweekly npm update'
+          commit-message: 'chore(deps): npm update'
+          body: |
+            Automated `npm update` from the biweekly maintenance workflow.
+
+            - Bumps within existing semver ranges only.
+            - Verified locally in CI: `npm run release:check` (lint + test + build + audit).
+          labels: |
+            dependencies
+            automated
+          delete-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-02
+
+### Added
+
+- Dependabot auto-merge workflow that enables squash auto-merge for patch and minor updates after CI passes; major updates remain manual.
+- Scheduled biweekly `npm update` workflow that runs on the 1st and 15th of each month (plus `workflow_dispatch`), verifies via `release:check`, and opens a PR with the lockfile diff.
+
+### Changed
+
+- Dependabot npm and github-actions updates now target `develop` instead of `master`, treating `develop` as the integration branch where bumps soak before promoting to `master`.
+- CI now runs on `develop` push and pull_request in addition to `master` and `main`.
+
+### Fixed
+
+- Reconciled `package.json` version with `CHANGELOG.md` after two release entries did not bump `package.json`.
+
 ## [1.6.2] - 2026-04-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Adds two GitHub Actions workflows: Dependabot auto-merge for patch/minor PRs (majors stay manual) and a biweekly scheduled `npm update` job that opens a PR after `release:check` passes.
- Retargets Dependabot npm + github-actions PRs from `master` to `develop`, with `develop` as the integration branch where bumps soak before promoting to `master`.
- Adds `develop` to CI triggers; reconciles `package.json` version with `CHANGELOG.md`; bumps to **1.7.0**.

## Test plan

- [x] CI green on `develop` (`feat(ci): add dependency automation on develop`, run 25250449894)
- [ ] CI green on this PR
- [ ] Manually trigger `Scheduled npm update` via `workflow_dispatch` and confirm it opens a PR against `develop`
- [ ] Wait for next Dependabot patch/minor PR (or close+reopen one of the 13 stale ones) and confirm auto-merge enables and lands after CI passes
- [ ] After merge: tag `v1.7.0` to fire the existing release workflow

## Follow-ups (not in this PR)

- Branch protection on `develop`: require `lint-and-test`, require up-to-date branches, 0 approvals (so Dependabot can self-merge)
- Retarget the 13 stale Dependabot PRs currently open against `master` (close + let Dependabot reopen against `develop`, or `@dependabot recreate` each)