### PR TITLE
chore: clean changelog + sync Dependabot bumps for v1.7.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'develop'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'
     directory: '/'
+    target-branch: 'develop'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master, main, develop]
   pull_request:
-    branches: [master, main]
+    branches: [master, main, develop]
 
 permissions:
   contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request_target:
+    branches: [develop]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduled-npm-update.yml
+++ b/.github/workflows/scheduled-npm-update.yml
@@ -1,0 +1,52 @@
+name: Scheduled npm update
+
+on:
+  schedule:
+    - cron: '0 6 1,15 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: develop
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Update dependencies within ranges
+        run: npm update
+        env:
+          HUSKY: 0
+
+      - name: Verify lint, test, build, audit
+        run: npm run release:check
+        env:
+          HUSKY: 0
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          base: develop
+          branch: chore/npm-update-${{ github.run_id }}
+          title: 'chore(deps): biweekly npm update'
+          commit-message: 'chore(deps): npm update'
+          body: |
+            Automated `npm update` from the biweekly maintenance workflow.
+
+            - Bumps within existing semver ranges only.
+            - Verified locally in CI: `npm run release:check` (lint + test + build + audit).
+          labels: |
+            dependencies
+            automated
+          delete-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [1.7.0] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-02
+
+### Added
+
+- Dependabot auto-merge workflow that enables squash auto-merge for patch and minor updates after CI passes; major updates remain manual.
+- Scheduled biweekly `npm update` workflow that runs on the 1st and 15th of each month (plus `workflow_dispatch`), verifies via `release:check`, and opens a PR with the lockfile diff.
+
+### Changed
+
+- Dependabot npm and github-actions updates now target `develop` instead of `master`, treating `develop` as the integration branch where bumps soak before promoting to `master`.
+- CI now runs on `develop` push and pull_request in addition to `master` and `main`.
+
+### Fixed
+
+- Reconciled `package.json` version with `CHANGELOG.md` after two release entries did not bump `package.json`.
+
 ## [1.6.2] - 2026-04-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@vitest/coverage-v8": "^4.1.4",
         "@vitest/ui": "^4.1.4",
         "autoprefixer": "^10.4.24",
-        "eslint": "^10.2.1",
+        "eslint": "^10.3.0",
         "globals": "^17.6.0",
         "htmlhint": "^1.8.1",
         "husky": "^9.1.7",
@@ -4133,9 +4133,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-vanilla-sass-lint",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "modern-normalize": "^3.0.1"
@@ -17,7 +17,7 @@
         "@vitest/ui": "^4.1.4",
         "autoprefixer": "^10.4.24",
         "eslint": "^10.2.1",
-        "globals": "^17.3.0",
+        "globals": "^17.6.0",
         "htmlhint": "^1.8.1",
         "husky": "^9.1.7",
         "jsdom": "^29.1.0",
@@ -4657,9 +4657,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@vitest/ui": "^4.1.4",
     "autoprefixer": "^10.4.24",
     "eslint": "^10.2.1",
-    "globals": "^17.3.0",
+    "globals": "^17.6.0",
     "htmlhint": "^1.8.1",
     "husky": "^9.1.7",
     "jsdom": "^29.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@vitest/coverage-v8": "^4.1.4",
     "@vitest/ui": "^4.1.4",
     "autoprefixer": "^10.4.24",
-    "eslint": "^10.2.1",
+    "eslint": "^10.3.0",
     "globals": "^17.6.0",
     "htmlhint": "^1.8.1",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- Drops the empty `[Unreleased]` section from `CHANGELOG.md` (everything is captured under 1.7.0).
- Syncs two Dependabot patch/minor bumps that auto-merged on develop after PR #30: `eslint` 10.2.1 → 10.3.0 (#32), `globals` 17.5.0 → 17.6.0 (#31).

This is the cut for tagging v1.7.0 on master.

## Test plan

- [x] CI green on develop (auto-merge fired only after CI passed for #31 / #32)
- [ ] CI green on this PR
- [ ] After merge: tag `v1.7.0` on master to trigger the release workflow