### PR TITLE
chore: sync main with develop (catch-up to v1.7.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,18 @@ jobs:
             echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Checkout tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: ${{ steps.tag.outputs.value }}
+
+      - name: Build release notes from CHANGELOG
+        run: node scripts/release-notes-from-changelog.mjs "${{ steps.tag.outputs.value }}" release-body.md
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: ${{ steps.tag.outputs.value }}
           name: ${{ steps.tag.outputs.value }}
-          generate_release_notes: true
+          body_path: release-body.md
+          generate_release_notes: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           ref: ${{ steps.tag.outputs.value }}
 
-      - name: Build release notes from CHANGELOG
+      - name: Build concise release notes
         run: node scripts/release-notes-from-changelog.mjs "${{ steps.tag.outputs.value }}" release-body.md
 
       - name: Publish GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ on:
         description: Existing tag to release (for manual reruns)
         required: true
         type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing tag to release (called from scheduled-patch-release)
+        required: true
+        type: string
 
 jobs:
   verify:
@@ -45,7 +51,7 @@ jobs:
         env:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ -n "${INPUT_TAG}" ]; then
             echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -6,10 +6,9 @@
 #   2. Opens a PR into develop and enables auto-merge (squash)
 #   3. Polls until the PR is merged (CI must pass), then tags the new develop HEAD and pushes the tag
 #
-# Release chain: tags pushed by GITHUB_TOKEN do NOT trigger other workflows, so the tag-push step
-# uses secrets.RELEASE_PAT (a PAT with `contents: write` on this repo) to push the tag — that
-# triggers `release.yml` on `push: tags: ['v*']`. Without RELEASE_PAT the tag is still created but
-# you would need to dispatch the Release workflow manually.
+# Release chain: tags pushed by GITHUB_TOKEN do NOT trigger other workflows, so we cannot rely on
+# `release.yml`'s `push: tags` trigger firing. Instead, after pushing the tag we invoke release.yml
+# directly via `workflow_call` from the `publish` job below — fully automatic, no PAT required.
 #
 # Netlify: set production branch to develop for deploy-on-tag flow, or merge develop → master when you want.
 # No auto-merge to master → avoids branch-protection / half-updated state issues.
@@ -32,6 +31,8 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.name }}
     steps:
       - name: Checkout develop
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -107,19 +108,22 @@ jobs:
           done
 
       - name: Tag merged commit and push tag
+        id: tag
         env:
           VERSION: ${{ steps.bump.outputs.version }}
-          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
         run: |
           set -euo pipefail
-          if [ -z "${RELEASE_PAT}" ]; then
-            echo "RELEASE_PAT secret is not set — required so the pushed tag triggers release.yml." >&2
-            exit 1
-          fi
           git fetch origin develop --tags
           git checkout develop
           git reset --hard origin/develop
           git tag "v${VERSION}"
-          git -c http.extraheader= \
-            -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${RELEASE_PAT}" \
-            push origin "refs/tags/v${VERSION}"
+          git push origin "refs/tags/v${VERSION}"
+          echo "name=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: release
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    permissions:
+      contents: write

--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -6,9 +6,12 @@
 #   2. Opens a PR into develop and enables auto-merge (squash)
 #   3. Polls until the PR is merged (CI must pass), then tags the new develop HEAD and pushes the tag
 #
-# Release chain: tags pushed by GITHUB_TOKEN do NOT trigger other workflows, so we cannot rely on
-# `release.yml`'s `push: tags` trigger firing. Instead, after pushing the tag we invoke release.yml
-# directly via `workflow_call` from the `publish` job below — fully automatic, no PAT required.
+# Why a PAT: events created by GITHUB_TOKEN do NOT trigger other workflows, so a PR opened with
+# the default token would never fire ci.yml — auto-merge would block forever on the missing
+# required check. We use secrets.RELEASE_PAT (fine-grained, this repo, contents+PRs read/write)
+# for checkout, branch push, PR create, and the tag push so CI fires and release.yml chains correctly.
+#
+# Release chain: release.yml is invoked directly via `workflow_call` from the `publish` job below.
 #
 # Netlify: set production branch to develop for deploy-on-tag flow, or merge develop → master when you want.
 # No auto-merge to master → avoids branch-protection / half-updated state issues.
@@ -39,6 +42,7 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -51,36 +55,88 @@ jobs:
         env:
           HUSKY: 0
 
+      # Re-run safe: if develop's HEAD is already a `chore(release): X.Y.Z` commit and the
+      # tag v<X.Y.Z> is missing on origin, skip the bump and reuse that version. This recovers
+      # cleanly from a previous run that merged the PR but failed before pushing the tag.
+      - name: Detect pending release on develop
+        id: pending
+        run: |
+          set -euo pipefail
+          SUBJECT="$(git log -1 --pretty=%s)"
+          if [[ "${SUBJECT}" =~ ^chore\(release\):\ ([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            EXISTING="${BASH_REMATCH[1]}"
+            if git ls-remote --exit-code --tags origin "refs/tags/v${EXISTING}" >/dev/null 2>&1; then
+              echo "develop HEAD is release ${EXISTING} and tag exists — nothing pending."
+              echo "version=" >> "$GITHUB_OUTPUT"
+            else
+              echo "develop HEAD is release ${EXISTING} but tag is missing — will reuse."
+              echo "version=${EXISTING}" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bump patch version and changelog
         id: bump
+        if: steps.pending.outputs.version == ''
         run: node scripts/bump-patch-maintenance.mjs
+
+      - name: Resolve version
+        id: version
+        env:
+          PENDING: ${{ steps.pending.outputs.version }}
+          BUMPED: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PENDING}" ]; then
+            echo "value=${PENDING}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${BUMPED}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Push release branch and open PR
         id: pr
+        if: steps.pending.outputs.version == ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.bump.outputs.version }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           BRANCH="release/v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "${BRANCH}"
-          git add package.json CHANGELOG.md
-          git commit -m "chore(release): ${VERSION}"
-          git push origin "${BRANCH}"
-          PR_URL="$(gh pr create \
-            --base develop \
-            --head "${BRANCH}" \
-            --title "chore(release): ${VERSION}" \
-            --body "Automated biweekly maintenance patch bump to v${VERSION}.")"
+
+          # Re-run safe: if an existing release branch / PR / tag is already there from a prior
+          # attempt, reuse it instead of failing.
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "Branch ${BRANCH} already exists on origin — reusing."
+          else
+            git checkout -b "${BRANCH}"
+            git add package.json CHANGELOG.md
+            git commit -m "chore(release): ${VERSION}"
+            git push origin "${BRANCH}"
+          fi
+
+          PR_URL="$(gh pr list --head "${BRANCH}" --base develop --state open --json url --jq '.[0].url // empty')"
+          if [ -z "${PR_URL}" ]; then
+            PR_URL="$(gh pr create \
+              --base develop \
+              --head "${BRANCH}" \
+              --title "chore(release): ${VERSION}" \
+              --body "Automated biweekly maintenance patch bump to v${VERSION}.")"
+          else
+            echo "Reusing existing PR ${PR_URL}"
+          fi
+
           echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           echo "url=${PR_URL}" >> "$GITHUB_OUTPUT"
-          gh pr merge --auto --squash --delete-branch "${PR_URL}"
+          gh pr merge --auto --squash --delete-branch "${PR_URL}" || \
+            echo "auto-merge already enabled or PR already merged — continuing"
 
       - name: Wait for PR to merge
+        if: steps.pending.outputs.version == ''
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
           PR_URL: ${{ steps.pr.outputs.url }}
         timeout-minutes: 20
         run: |
@@ -110,14 +166,21 @@ jobs:
       - name: Tag merged commit and push tag
         id: tag
         env:
-          VERSION: ${{ steps.bump.outputs.version }}
+          VERSION: ${{ steps.version.outputs.value }}
         run: |
           set -euo pipefail
           git fetch origin develop --tags
           git checkout develop
           git reset --hard origin/develop
-          git tag "v${VERSION}"
-          git push origin "refs/tags/v${VERSION}"
+
+          # Re-run safe: if v<VERSION> already exists on origin, do not retag — just emit the
+          # output so the publish job can still pick it up (or no-op if release already published).
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "Tag v${VERSION} already exists on origin — skipping tag push."
+          else
+            git tag "v${VERSION}"
+            git push origin "refs/tags/v${VERSION}"
+          fi
           echo "name=v${VERSION}" >> "$GITHUB_OUTPUT"
 
   publish:

--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -1,5 +1,15 @@
-# Biweekly: bump patch + prepend CHANGELOG on develop, push develop, push tag v* (triggers Release workflow).
+# Biweekly: bump patch + prepend CHANGELOG via PR into develop, then tag the merge commit (triggers Release workflow).
 # Cron 3rd & 17th UTC — after npm update PRs on 1st/15th have time to land on develop.
+#
+# Branch protection on develop requires PRs + the lint-and-test (22.x) check, so this workflow:
+#   1. Pushes the bump to a release/v<version> branch
+#   2. Opens a PR into develop and enables auto-merge (squash)
+#   3. Polls until the PR is merged (CI must pass), then tags the new develop HEAD and pushes the tag
+#
+# Release chain: tags pushed by GITHUB_TOKEN do NOT trigger other workflows, so the tag-push step
+# uses secrets.RELEASE_PAT (a PAT with `contents: write` on this repo) to push the tag — that
+# triggers `release.yml` on `push: tags: ['v*']`. Without RELEASE_PAT the tag is still created but
+# you would need to dispatch the Release workflow manually.
 #
 # Netlify: set production branch to develop for deploy-on-tag flow, or merge develop → master when you want.
 # No auto-merge to master → avoids branch-protection / half-updated state issues.
@@ -13,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: scheduled-patch-release
@@ -43,12 +54,72 @@ jobs:
         id: bump
         run: node scripts/bump-patch-maintenance.mjs
 
-      - name: Commit, push develop, push tag
+      - name: Push release branch and open PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
         run: |
+          set -euo pipefail
+          BRANCH="release/v${VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
           git add package.json CHANGELOG.md
-          git commit -m "chore(release): ${{ steps.bump.outputs.version }}"
-          git push origin HEAD:develop
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push origin "refs/tags/v${{ steps.bump.outputs.version }}"
+          git commit -m "chore(release): ${VERSION}"
+          git push origin "${BRANCH}"
+          PR_URL="$(gh pr create \
+            --base develop \
+            --head "${BRANCH}" \
+            --title "chore(release): ${VERSION}" \
+            --body "Automated biweekly maintenance patch bump to v${VERSION}.")"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "url=${PR_URL}" >> "$GITHUB_OUTPUT"
+          gh pr merge --auto --squash --delete-branch "${PR_URL}"
+
+      - name: Wait for PR to merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        timeout-minutes: 20
+        run: |
+          set -euo pipefail
+          while :; do
+            STATE="$(gh pr view "${PR_URL}" --json state --jq .state)"
+            case "${STATE}" in
+              MERGED)
+                echo "PR merged."
+                break
+                ;;
+              CLOSED)
+                echo "PR was closed without merging." >&2
+                exit 1
+                ;;
+              OPEN)
+                echo "PR still open, waiting..."
+                sleep 20
+                ;;
+              *)
+                echo "Unexpected PR state: ${STATE}" >&2
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Tag merged commit and push tag
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+          RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_PAT}" ]; then
+            echo "RELEASE_PAT secret is not set — required so the pushed tag triggers release.yml." >&2
+            exit 1
+          fi
+          git fetch origin develop --tags
+          git checkout develop
+          git reset --hard origin/develop
+          git tag "v${VERSION}"
+          git -c http.extraheader= \
+            -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${RELEASE_PAT}" \
+            push origin "refs/tags/v${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tag releases publish short bullet summaries instead of automated commit listings.
 
 
+
+## [1.7.4] - 2026-05-08
+
+### Changed
+
+- Automated biweekly maintenance patch: semver patch bump after `release:check`, commit on `develop`, tag; GitHub Release follows the tag; Netlify deploy uses whichever branch you configured (often `develop`).
+
 ## [1.7.3] - 2026-05-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tag releases publish short bullet summaries instead of automated commit listings.
 
+
+## [1.7.3] - 2026-05-03
+
+### Changed
+
+- Automated biweekly maintenance patch: semver patch bump after `release:check`, commit on `develop`, tag; GitHub Release follows the tag; Netlify deploy uses whichever branch you configured (often `develop`).
+
 ## [1.7.2] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- GitHub Releases are built from the matching `CHANGELOG.md` section for each tag (no auto-generated “What’s Changed” list with @mentions from commits or PRs).
+- Tag releases publish short bullet summaries instead of automated commit listings.
 
 ## [1.7.2] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- GitHub Releases are built from the matching `CHANGELOG.md` section for each tag (no auto-generated “What’s Changed” list with @mentions from commits or PRs).
+
 ## [1.7.2] - 2026-05-02
 
 ### Added
@@ -57,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `stylelint` from 17.8.0 to 17.9.1
   - `terser` from 5.46.1 to 5.46.2
   - `lint-staged` from 15.5.2 to 16.4.0
+
+## [1.6.1] - 2026-04-28
+
+### Changed
+
+- CI and GitHub Actions release workflow hardening (#13).
+- Frontend security defaults and repository hygiene tightened (#14).
 
 ## [1.6.0] - 2026-04-17
 
@@ -115,6 +128,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README with testing section
 - Added documentation for new scripts and features
 - Added note about `.nvmrc` usage in README
+
+## [1.5.1] - 2026-04-17
+
+### Changed
+
+- Patch maintenance on `master` (repository housekeeping).
 
 ## [1.4.0] - Previous Release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-vanilla-sass-lint",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "modern-normalize": "^3.0.1"
@@ -23,7 +23,7 @@
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.4.0",
-        "postcss": "^8.5.12",
+        "postcss": "^8.5.13",
         "prettier": "^3.8.1",
         "sass-embedded": "^1.97.3",
         "stylelint": "^17.9.1",
@@ -6351,9 +6351,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",
     "lint-staged": "^16.4.0",
-    "postcss": "^8.5.12",
+    "postcss": "^8.5.13",
     "prettier": "^3.8.1",
     "sass-embedded": "^1.97.3",
     "stylelint": "^17.9.1",

--- a/scripts/release-notes-from-changelog.mjs
+++ b/scripts/release-notes-from-changelog.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Extract the Keep-a-Changelog section for a version and write it to a file
- * (for GitHub Release bodies without auto-generated @username lines).
+ * Build a concise GitHub Release body from a Keep-a-Changelog section (flat bullets
+ * only, no ### headings — suitable for tagged releases).
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
@@ -9,7 +9,10 @@ import { fileURLToPath } from 'node:url';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-function extractSection(changelog, version) {
+const MAX_BULLETS = 6;
+
+/** Raw section lines between ## [version] and next ## [ */
+function extractSectionLines(changelog, version) {
   const lines = changelog.split(/\r?\n/);
   const header = `## [${version}]`;
   const idx = lines.findIndex((l) => l.startsWith(header));
@@ -19,8 +22,43 @@ function extractSection(changelog, version) {
     if (/^## \[/.test(lines[i])) break;
     body.push(lines[i]);
   }
-  const text = body.join('\n').trim();
-  return text.length > 0 ? text : null;
+  return body.join('\n').trim().length > 0 ? body : null;
+}
+
+/** Omit ### headings; merge continued sub-bullets into one `-` item per top-level bullet. */
+function sectionToBullets(sectionLines) {
+  const bullets = [];
+  /** @type {string | null} */
+  let acc = null;
+
+  function flush() {
+    if (acc !== null && acc.length > 0) {
+      bullets.push(acc.trim());
+      acc = null;
+    }
+  }
+
+  for (const line of sectionLines) {
+    const trimmed = line.trimEnd();
+    if (/^### /.test(trimmed)) {
+      flush();
+      continue;
+    }
+    if (trimmed === '') continue;
+
+    const top = /^- (.+)$/.exec(trimmed);
+    if (top) {
+      flush();
+      acc = top[1];
+      continue;
+    }
+    const sub = /^\s*-\s+(.+)$/.exec(trimmed);
+    if (sub && acc !== null) {
+      acc += acc.endsWith(':') ? ` ${sub[1]}` : ` · ${sub[1]}`;
+    }
+  }
+  flush();
+  return bullets;
 }
 
 const versionArg = process.argv[2];
@@ -33,9 +71,22 @@ if (!versionArg || !outPath) {
 }
 const version = versionArg.replace(/^v/, '');
 const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
-const section = extractSection(changelog, version);
-if (!section) {
+const rawLines = extractSectionLines(changelog, version);
+if (!rawLines) {
   console.error(`No non-empty CHANGELOG section found for [${version}]`);
   process.exit(1);
 }
-writeFileSync(outPath, `${section}\n`);
+
+let bullets = sectionToBullets(rawLines);
+if (bullets.length === 0) {
+  console.error(`No bullets parsed for [${version}]`);
+  process.exit(1);
+}
+
+if (bullets.length > MAX_BULLETS) {
+  bullets = bullets.slice(0, MAX_BULLETS);
+  bullets.push('…');
+}
+
+const body = bullets.map((b) => `- ${b}`).join('\n');
+writeFileSync(outPath, `${body}\n`);

--- a/scripts/release-notes-from-changelog.mjs
+++ b/scripts/release-notes-from-changelog.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Extract the Keep-a-Changelog section for a version and write it to a file
+ * (for GitHub Release bodies without auto-generated @username lines).
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function extractSection(changelog, version) {
+  const lines = changelog.split(/\r?\n/);
+  const header = `## [${version}]`;
+  const idx = lines.findIndex((l) => l.startsWith(header));
+  if (idx === -1) return null;
+  const body = [];
+  for (let i = idx + 1; i < lines.length; i++) {
+    if (/^## \[/.test(lines[i])) break;
+    body.push(lines[i]);
+  }
+  const text = body.join('\n').trim();
+  return text.length > 0 ? text : null;
+}
+
+const versionArg = process.argv[2];
+const outPath = process.argv[3];
+if (!versionArg || !outPath) {
+  console.error(
+    'Usage: release-notes-from-changelog.mjs <vX.Y.Z|X.Y.Z> <outfile.md>'
+  );
+  process.exit(1);
+}
+const version = versionArg.replace(/^v/, '');
+const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
+const section = extractSection(changelog, version);
+if (!section) {
+  console.error(`No non-empty CHANGELOG section found for [${version}]`);
+  process.exit(1);
+}
+writeFileSync(outPath, `${section}\n`);


### PR DESCRIPTION
One-time catch-up so future automated develop → main syncs are clean fast-forwards. main is 8 commits behind develop, 0 ahead. Will merge with the merge-commit strategy.