### PR TITLE
ci: fast-forward main to develop after tag push

### DIFF
--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -183,6 +183,11 @@ jobs:
           fi
           echo "name=v${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # Fast-forward main to develop. Refuses non-fast-forward pushes by default,
+      # so if main has diverged the workflow fails loudly instead of overwriting.
+      - name: Sync main with develop
+        run: git push origin develop:main
+
   publish:
     needs: release
     uses: ./.github/workflows/release.yml


### PR DESCRIPTION
## Summary
- Adds a final 'Sync main with develop' step to the release job in scheduled-patch-release.yml.
- Default git push refuses non-fast-forward updates, so the step fails loudly if main has diverged instead of overwriting.

## Test plan
- [x] CI passes on this PR
- [ ] Merge, then trigger Scheduled patch release to confirm main fast-forwards after the tag push.