### PR TITLE
chore: collapse double blank line between CHANGELOG sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tag releases publish short bullet summaries instead of automated commit listings.
 
-
-
 ## [1.7.4] - 2026-05-08
 
 ### Changed

--- a/scripts/bump-patch-maintenance.mjs
+++ b/scripts/bump-patch-maintenance.mjs
@@ -27,6 +27,13 @@ function prependChangelogEntry(changelogBody, version, date) {
   while (i < lines.length && !/^## \[\d+\.\d+\.\d+\]/.test(lines[i])) {
     i += 1;
   }
+  // Drop any pre-existing blank lines immediately before the next version
+  // section so the inserted block always sits with exactly one blank line
+  // separating it from whatever came above (Unreleased section, intro, etc.).
+  while (i > 0 && lines[i - 1] === '') {
+    i -= 1;
+    lines.splice(i, 1);
+  }
   const block = [
     '',
     `## [${version}] - ${date}`,


### PR DESCRIPTION
Cosmetic-only. Script normalises whitespace before insertion; one-time cleanup of the existing double blank line.