### PR TITLE
fix(ci): scope audit gate to prod deps and unblock release automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,10 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Audit dependencies
-        run: npm audit --audit-level=moderate
+      # Gate on production dependencies only. Dev-tool advisories are surfaced by the
+      # next step but must not be able to freeze releases when no fix is published yet.
+      - name: Audit production dependencies
+        run: npm run audit:prod
+
+      - name: Audit full tree (advisory, non-blocking)
+        run: npm audit --audit-level=moderate || true

--- a/.github/workflows/scheduled-npm-update.yml
+++ b/.github/workflows/scheduled-npm-update.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Open pull request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
+          # PRs opened with the default GITHUB_TOKEN do not trigger workflows, so ci.yml
+          # would never run and the required lint-and-test (22.x) check could never pass.
+          token: ${{ secrets.RELEASE_PAT }}
           base: develop
           branch: chore/npm-update-${{ github.run_id }}
           title: 'chore(deps): biweekly npm update'

--- a/.github/workflows/scheduled-patch-release.yml
+++ b/.github/workflows/scheduled-patch-release.yml
@@ -183,10 +183,19 @@ jobs:
           fi
           echo "name=v${VERSION}" >> "$GITHUB_OUTPUT"
 
-      # Fast-forward main to develop. Refuses non-fast-forward pushes by default,
-      # so if main has diverged the workflow fails loudly instead of overwriting.
+      # Bring main up to develop. A plain fast-forward push breaks permanently the first
+      # time main gains a commit develop does not have (security PRs from dependabot land
+      # on the default branch), so merge instead. History is preserved either way: when
+      # main is strictly behind, the merge is a fast-forward and no merge commit appears.
       - name: Sync main with develop
-        run: git push origin develop:main
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main develop
+          git checkout -B sync-main origin/main
+          git merge --no-edit origin/develop
+          git push origin sync-main:main
 
   publish:
     needs: release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,20 +6,36 @@ Entry point for AI agents in this repository. Expand over time; start here for s
 
 ## Stack
 
-<!-- TODO: one-line stack summary -->
+Vite 8 + vanilla ES modules + Sass (`sass-embedded`), linted by ESLint, Stylelint, HTMLHint, and html-validate; Vitest (jsdom) for tests; Prettier for formatting; Husky + lint-staged pre-commit. Node 22 (`.nvmrc`). Single static page: `index.html` mounts `#app`, `src/assets/js/main.js` builds the DOM.
 
 ## Build / test
 
-<!-- TODO: primary commands -->
+- `npm run dev` (port 3000), `npm run build`, `npm run preview`
+- `npm run lint`, `npm run lint:fix`, `npm run format`, `npm run format:check`
+- `npm run test:ci`, `npm run test:coverage`
+- `npm run release:check` is the CI gate: lint, format check, tests, build, `npm run audit:prod`
+
+## Audit policy
+
+`release:check` blocks on **production dependencies only** (`npm audit --omit=dev --audit-level=moderate`). CI runs a full-tree `npm audit` as a separate non-blocking step so dev-toolchain advisories stay visible.
+
+Do not re-scope `release:check` to the full tree. A dev-only advisory with no published fix would then block every PR, every scheduled npm update, and every release at once, and no single dependency PR could clear it. Clear dev advisories with `npm run audit:fix`. Reach for `overrides` in `package.json` only when no upstream fix exists, and use a caret range, never an exact pin: an exact pin at a version that later turns vulnerable cannot be lifted by `npm update`.
 
 ## Git
 
-<!-- TODO: default branch, PR policy, deploy trigger if any -->
+- Default branch on GitHub is `main`, but **all work branches from and targets `develop`**.
+- `develop` is protected: PR required, `lint-and-test (22.x)` is the required status check, strict mode on (branch must be up to date). Never rename that job or its `22.x` matrix entry; the protection rule matches the check by name.
+- Releases: `chore(release): X.Y.Z` merges into `develop`, the merge commit is tagged `vX.Y.Z`, `release.yml` publishes the GitHub Release from `CHANGELOG.md` via `scripts/release-notes-from-changelog.mjs`, and `scheduled-patch-release.yml` merges `develop` into `main`.
+- Dependabot targets `develop` (`.github/dependabot.yml`). Its *security* PRs still land on `main`, because setting `target-branch` disables security updates for that config; `dependabot-auto-merge.yml` only listens on `develop`, so those need manual handling.
+- Automation that opens PRs must pass `secrets.RELEASE_PAT`, not the default `GITHUB_TOKEN`: PRs created by `GITHUB_TOKEN` do not trigger workflows, so the required check never runs and auto-merge blocks forever.
+- Conventional commit subjects, imperative mood, first line under 72 characters.
+- Changelog: prepend to `CHANGELOG.md` following its own header rules (Keep a Changelog, imperative voice, one line per bullet, 120 visible characters max, **Build / Chore / CI / Docs / Enhance / Feat / Fix / Perf / Revert / Sec / Style** labels).
 
 ## Do not
 
 - Commit secrets (`.env`, credentials).
 - Force-push shared branches unless explicitly requested.
+- Attribute commits or PRs to an agent: no agent co-author trailers, no generated-with footers.
 
 ## Cursor CLI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; append **(WIP)** only for incomplete work.
 
+## [1.10.6] - 2026-08-18
+
+- **CI:** Scope the `release:check` audit gate to production deps; keep full-tree `npm audit` as a non-blocking step.
+- **Sec:** Bump `brace-expansion` 5.0.9, `fast-uri` 3.1.5, `js-yaml` 4.3.1, and `nanoid` 3.3.18 via `npm audit fix`.
+- **Build:** Add an `audit:prod` script and drop the now-redundant `brace-expansion` and `fast-uri` overrides.
+- **CI:** Open scheduled `npm update` PRs with `RELEASE_PAT` so `ci.yml` fires and the required check can report.
+- **Fix:** Merge `develop` into `main` in the release sync step; the fast-forward push failed on every run since June.
+- **Docs:** Fill in `AGENTS.md` and document the audit gate and release flow in `README.md` and `CONTRIBUTING.md`.
+
 ## [1.10.5] - 2026-08-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@ Guidance for working in this repo.
 - `npm run dev` (port 3000), `npm run build`, `npm run preview`
 - `npm run lint`, `npm run lint:fix`, `npm run format`
 - `npm run test:ci`, `npm run test:coverage`
+- `npm run release:check`: the CI gate (lint + format check + tests + build + `npm run audit:prod`)
+- `npm run audit:prod`: `npm audit --omit=dev --audit-level=moderate`; full-tree `npm audit` runs in CI as a non-blocking advisory step
 - `npm run analyze` (bundle visualizer to `dist/stats.html`)
 - `node scripts/screenshot.mjs <outDir>` captures the page at desktop/tablet/mobile (needs Playwright + system Chrome; see the `perf-audit` skill).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,9 @@ See [README.md](./README.md#quick-start) for the Quick start path.
 
 ## Workflow
 
-Before opening a PR, run `npm run release:check`. It runs the same gates as CI: lint, format check, test, build, and `npm audit` at the moderate threshold.
+Before opening a PR, run `npm run release:check`. It runs the same gates as CI: lint, format check, test, build, and `npm run audit:prod` (`npm audit --omit=dev` at the moderate threshold).
+
+The gate is scoped to production dependencies on purpose. CI still prints a full-tree `npm audit` as a non-blocking step, so dev-toolchain advisories stay visible; clear them with `npm run audit:fix` rather than letting them block a release.
 
 Pre-commit hooks (Husky + lint-staged) run ESLint, Stylelint, and Prettier on staged files. If they fail, fix the reported issues and commit again.
 

--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -10,5 +10,5 @@ Open items only. Items previously listed here that have since shipped (license f
 
 ## Build / Config
 
-- **Audit gate**: `release:check` runs `npm audit --audit-level=moderate`. Tightening to `--audit-level=high` would fail loudly on high/critical without churning on moderate noise.
+- **Dev-advisory triage**: `release:check` now gates on production deps only, with a non-blocking full-tree audit in CI. Consider failing the advisory step when a dev advisory is high/critical *and* a fixed version exists, so genuinely actionable ones are not ignored.
 - **HTMLHint semantics**: enable rules for ARIA, alt text, semantic-element usage if not covered by `html-validate:recommended`.

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Dev server runs on `http://localhost:3000`.
 | `npm run test:ui`       | Vitest UI                                                     |
 | `npm run test:coverage` | Vitest coverage report                                        |
 | `npm run analyze`       | Build with bundle visualizer, opens `dist/stats.html`         |
-| `npm run audit`         | `npm audit`                                                   |
+| `npm run audit`         | `npm audit` across the full tree (dev included)               |
+| `npm run audit:prod`    | `npm audit --omit=dev --audit-level=moderate`                 |
 | `npm run audit:fix`     | `npm audit fix`                                               |
-| `npm run release:check` | Same gates as CI: lint, format, test, build, audit (moderate) |
+| `npm run release:check` | Same gates as CI: lint, format, test, build, `audit:prod`     |
 | `npm run clean`         | Remove `dist/`                                                |
 
 ## Project layout
@@ -81,9 +82,13 @@ Production build emits ESM only and uses `sourcemap: 'hidden'`: maps are produce
 
 ## Releases
 
-Changes land on `develop`, then a release commit (`chore(release): X.Y.Z`) merges to `develop`, the merge is tagged `vX.Y.Z`, and `main` is fast-forwarded. The `release.yml` workflow then runs `release:check` against the tag and publishes a GitHub Release whose body is built from `CHANGELOG.md` by `scripts/release-notes-from-changelog.mjs`.
+Changes land on `develop`, then a release commit (`chore(release): X.Y.Z`) merges to `develop`, the merge is tagged `vX.Y.Z`, and `main` is merged up from `develop`. The `release.yml` workflow then runs `release:check` against the tag and publishes a GitHub Release whose body is built from `CHANGELOG.md` by `scripts/release-notes-from-changelog.mjs`.
 
-A scheduled workflow (`scheduled-patch-release.yml`) runs the bump, PR, merge, tag, and `main` fast-forward biweekly on the 3rd and 17th UTC. See [`CHANGELOG.md`](./CHANGELOG.md) for the full history.
+A scheduled workflow (`scheduled-patch-release.yml`) runs the bump, PR, merge, tag, and `main` sync biweekly on the 3rd and 17th UTC. The sync merges rather than fast-forwards, so a commit that lands on `main` alone (Dependabot security PRs target the default branch) cannot wedge the pipeline. See [`CHANGELOG.md`](./CHANGELOG.md) for the full history.
+
+### Audit gate
+
+`release:check` blocks on production dependencies only (`npm run audit:prod`). CI additionally runs a non-blocking full-tree `npm audit` so dev-toolchain advisories stay visible without being able to freeze releases when upstream has not published a fix yet. Run `npm run audit:fix` to clear them.
 
 ## Requirements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.3",
+  "version": "1.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-vanilla-sass-lint",
-      "version": "1.10.3",
+      "version": "1.10.6",
       "license": "MIT",
       "dependencies": {
         "modern-normalize": "^3.0.1"
@@ -1936,9 +1936,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2943,9 +2943,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -3025,6 +3025,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
@@ -3813,9 +3830,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -4578,9 +4595,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -12,12 +12,13 @@
     "format:check": "prettier --check \"src/**/*.{js,css,scss,html,md}\" index.html",
     "clean": "rm -rf dist",
     "audit": "npm audit",
+    "audit:prod": "npm audit --omit=dev --audit-level=moderate",
     "audit:fix": "npm audit fix",
     "test": "vitest",
     "test:ci": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
-    "release:check": "npm run lint && npm run format:check && npm run test:ci && npm run build && npm audit --audit-level=moderate",
+    "release:check": "npm run lint && npm run format:check && npm run test:ci && npm run build && npm run audit:prod",
     "analyze": "vite build --mode analyze",
     "prepare": "husky"
   },
@@ -85,9 +86,5 @@
   },
   "dependencies": {
     "modern-normalize": "^3.0.1"
-  },
-  "overrides": {
-    "brace-expansion": "^5.0.8",
-    "fast-uri": "^3.1.4"
   }
 }


### PR DESCRIPTION
## Why

`release:check` ended with a repo-global `npm audit --audit-level=moderate`. Every live advisory (`brace-expansion`, `fast-uri`, `js-yaml`, `nanoid`) is a transitive **dev-only** dependency of the eslint/vite/jsdom toolchain. Production deps are `modern-normalize` only, and a prod-scoped audit was already clean.

Because the gate is repo-global and `lint-and-test (22.x)` is a required, strict check on `develop`, no single dependency PR could turn CI green. Consequences:

- `Scheduled patch release` #14 failed at *Install and verify*.
- Every Dependabot check failed with the same audit output; 13 PRs sat at `BLOCKED` with auto-merge never completing.
- `Sync main with develop` has failed on 5 consecutive runs since 2026-06-17, so the `publish` job was skipped every time.
- Scheduled `npm update` PRs report *no checks reported on the branch* and can never satisfy the required check.

## What changed

1. **Audit scope.** New `audit:prod` script (`npm audit --omit=dev --audit-level=moderate`); `release:check` gates on it. `ci.yml` keeps a full-tree `npm audit` as a separate `|| true` step so dev advisories stay visible without freezing releases.
2. **Lockfile.** `npm audit fix` bumps `brace-expansion` 5.0.9, `fast-uri` 3.1.5, `js-yaml` 4.3.1, `nanoid` 3.3.18. Full-tree `npm audit` now reports `found 0 vulnerabilities`. The `overrides` block is dropped as redundant. No `package.json` dependency ranges changed.
3. **Token.** `scheduled-npm-update.yml` passes `secrets.RELEASE_PAT` to `create-pull-request`. PRs opened with `GITHUB_TOKEN` do not trigger workflows, so `ci.yml` never fired.
4. **Main sync.** `Sync main with develop` merges instead of fast-forward pushing, so a commit that lands on `main` alone (Dependabot security PRs target the default branch) cannot wedge the job permanently. When `main` is strictly behind, the merge is still a fast-forward.
5. **Docs.** `AGENTS.md` filled in (stack, build, audit policy, branch/release rules). Audit gate and release flow documented in `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`. `IMPROVEMENTS.md` open item rewritten. `CHANGELOG.md` + version bumped to 1.10.6.

The `lint-and-test` job name and its `22.x` matrix are unchanged, so the required-status-check context still matches.

## Verification

- `npm audit` -> `found 0 vulnerabilities` (full tree)
- `npm run audit:prod` -> exit 0
- `npm run release:check` -> lint, format:check, 7/7 tests, build, prod audit all pass
- `node scripts/release-notes-from-changelog.mjs v1.10.6` renders the 1.10.6 section cleanly

## Follow-up (not in this PR)

`origin/main` is 3 commits ahead of `develop`; it needs a one-time local merge before the next scheduled release run.