### PR TITLE
fix(ci): install from lockfile before npm update

### DIFF
--- a/.github/workflows/scheduled-npm-update.yml
+++ b/.github/workflows/scheduled-npm-update.yml
@@ -24,6 +24,15 @@ jobs:
           node-version: 22.x
           cache: 'npm'
 
+      # Materialize the lockfile tree before updating. Running `npm update` against a bare
+      # checkout makes arborist build an ideal tree from nothing, which crashes with
+      # "Cannot read properties of null (reading 'edgesOut')" on the npm bundled with
+      # Node 22.x. Kept in step with the sibling repo, where that crash was observed.
+      - name: Install from lockfile
+        run: npm ci
+        env:
+          HUSKY: 0
+
       - name: Update dependencies within ranges
         run: npm update
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; append **(WIP)** only for incomplete work.
 
+## [1.10.7] - 2026-08-18
+
+- **Fix:** Run `npm ci` before `npm update` in the scheduled workflow; updating a bare checkout crashes npm's arborist.
+- **Build:** Bump vite 8.2.1 ([#136](https://github.com/marcop135/vite-vanilla-sass-lint/pull/136)), eslint 10.8.1 ([#138](https://github.com/marcop135/vite-vanilla-sass-lint/pull/138)), postcss 8.5.26 ([#137](https://github.com/marcop135/vite-vanilla-sass-lint/pull/137)), terser 5.50.0 ([#139](https://github.com/marcop135/vite-vanilla-sass-lint/pull/139)), globals 17.11.0 ([#133](https://github.com/marcop135/vite-vanilla-sass-lint/pull/133)).
+- **Build:** Apply the biweekly `npm update`: sass-embedded 1.102.0, rollup-plugin-visualizer 7.1.1, plus transitive dev bumps ([#142](https://github.com/marcop135/vite-vanilla-sass-lint/pull/142)).
+
 ## [1.10.6] - 2026-08-18
 
 - **CI:** Scope the `release:check` audit gate to production deps; keep full-tree `npm audit` as a non-blocking step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-vanilla-sass-lint",
-      "version": "1.10.6",
+      "version": "1.10.7",
       "license": "MIT",
       "dependencies": {
         "modern-normalize": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Follow-up to #141. The scheduled npm update workflow died at *Update dependencies within ranges* in the sibling repo (`vite-react-tailwind-lint`, [run 32148289066](https://github.com/marcop135/vite-react-tailwind-lint/actions/runs/32148289066)) with:

```
npm error Cannot read properties of null (reading 'edgesOut')
```

`npm update` ran against a bare checkout, so arborist had to build an ideal tree from nothing. Running `npm ci` first materializes the lockfile tree it expects. This repo's run ([32147821647](https://github.com/marcop135/vite-vanilla-sass-lint/actions/runs/32147821647)) happened to survive without it; the step is added here so both workflows stay identical.

Also bumps to 1.10.7 and records the dependency work that landed since v1.10.6 (#136, #138, #137, #139, #133, #142) in the changelog.

Verified: `npm run release:check` passes; `npm audit` reports 0 vulnerabilities.