### PR TITLE
chore(release): 1.10.8

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-# Environment Variables Example
-# Copy this file to .env and update with your values
-
-# Vite Configuration
-# VITE_API_URL=https://api.example.com
-# VITE_APP_TITLE=My App
-
-# Development
-# NODE_ENV=development

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ Thumbs.db
 # Log files
 *.log
 
-.sass-cache/
-
 # Local environment files
 *.env
 *.local
@@ -28,5 +26,3 @@ coverage/
 
 # Netlify CLI local state
 .netlify/
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; append **(WIP)** only for incomplete work.
 
+## [1.10.8] - 2026-08-18
+
+- **Chore:** Delete the unused `.env.example`; the project reads no `VITE_` variable and nothing referenced the file.
+- **Chore:** Drop the stale `.sass-cache/` ignore rule; `sass-embedded` never writes that directory.
+
 ## [1.10.7] - 2026-08-18
 
 - **Fix:** Run `npm ci` before `npm update` in the scheduled workflow; updating a bare checkout crashes npm's arborist.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-vanilla-sass-lint",
-      "version": "1.10.7",
+      "version": "1.10.8",
       "license": "MIT",
       "dependencies": {
         "modern-normalize": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Removes leftovers with no consumer and cuts the 1.10.8 release.

- `.env.example`: no `VITE_` variable is read anywhere in `src/` or `index.html`, and no doc referenced the file.
- `.sass-cache/` in `.gitignore`: `sass-embedded` never writes that directory; it is a leftover from node-sass.

`npm run release:check` passes locally: lint, format check, 7/7 tests, build, `audit:prod` at 0 vulnerabilities.
