### PR TITLE
ci: auto-merge the npm update PR and route security PRs to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,16 @@
+# No `target-branch` on purpose. Setting it disables Dependabot *security* updates for that
+# ecosystem, which would push security PRs onto the default branch with no automation covering
+# them. `develop` is the default branch, so version and security PRs both land there and
+# `dependabot-auto-merge.yml` handles patch and minor.
 version: 2
 updates:
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'develop'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10
   - package-ecosystem: 'github-actions'
     directory: '/'
-    target-branch: 'develop'
     schedule:
       interval: 'weekly'
     open-pull-requests-limit: 10

--- a/.github/workflows/scheduled-npm-update.yml
+++ b/.github/workflows/scheduled-npm-update.yml
@@ -44,6 +44,7 @@ jobs:
           HUSKY: 0
 
       - name: Open pull request
+        id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           # PRs opened with the default GITHUB_TOKEN do not trigger workflows, so ci.yml
@@ -62,3 +63,15 @@ jobs:
             dependencies
             automated
           delete-branch: true
+
+      # develop is protected with the required lint-and-test (22.x) check, so --auto queues the
+      # merge behind CI rather than merging on the spot. release:check already passed above; this
+      # is the second gate. Without this the PR sits open and the 3rd/17th release ships without it.
+      # The guard skips no-op runs: when npm update changes nothing, no PR is opened and the
+      # step outputs are empty.
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created' || steps.cpr.outputs.pull-request-operation == 'updated'
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ steps.cpr.outputs.pull-request-url }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,10 @@ Do not re-scope `release:check` to the full tree. A dev-only advisory with no pu
 
 ## Git
 
-- Default branch on GitHub is `main`, but **all work branches from and targets `develop`**.
+- `develop` is the default branch and the integration branch: **all work branches from and targets `develop`**. `main` is the released mirror, synced by the release workflow and tagged at every version.
 - `develop` is protected: PR required, `lint-and-test (22.x)` is the required status check, strict mode on (branch must be up to date). Never rename that job or its `22.x` matrix entry; the protection rule matches the check by name.
 - Releases: `chore(release): X.Y.Z` merges into `develop`, the merge commit is tagged `vX.Y.Z`, `release.yml` publishes the GitHub Release from `CHANGELOG.md` via `scripts/release-notes-from-changelog.mjs`, and `scheduled-patch-release.yml` merges `develop` into `main`.
-- Dependabot targets `develop` (`.github/dependabot.yml`). Its *security* PRs still land on `main`, because setting `target-branch` disables security updates for that config; `dependabot-auto-merge.yml` only listens on `develop`, so those need manual handling.
+- Dependabot targets `develop` because `develop` is the default branch. Never add `target-branch` to `.github/dependabot.yml`: setting it disables _security_ updates for that config, so security PRs would fall back to the default branch outside the ecosystem's own routing. `dependabot-auto-merge.yml` auto-merges patch and minor on `develop`; majors are reviewed by hand.
 - Automation that opens PRs must pass `secrets.RELEASE_PAT`, not the default `GITHUB_TOKEN`: PRs created by `GITHUB_TOKEN` do not trigger workflows, so the required check never runs and auto-merge blocks forever.
 - Conventional commit subjects, imperative mood, first line under 72 characters.
 - Changelog: prepend to `CHANGELOG.md` following its own header rules (Keep a Changelog, imperative voice, one line per bullet, 120 visible characters max, **Build / Chore / CI / Docs / Enhance / Feat / Fix / Perf / Revert / Sec / Style** labels).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 **Labels:** **Build**, **Chore**, **CI**, **Docs**, **Enhance**, **Feat**, **Fix**, **Perf**, **Revert**, **Sec**, **Style**; append **(WIP)** only for incomplete work.
 
+## [1.10.9] - 2026-08-28
+
+- **CI:** Enable auto-merge on the biweekly `npm update` PR so it lands before the patch release instead of sitting open.
+- **CI:** Drop `target-branch` from `dependabot.yml` and make `develop` the default branch, so security PRs stop landing on `main`.
+- **Docs:** Record the dependency intake path in `README.md`, `AGENTS.md`, and `CONTRIBUTING.md`; pin the degit example to `#main`.
+
 ## [1.10.8] - 2026-08-18
 
 - **Chore:** Delete the unused `.env.example`; the project reads no `VITE_` variable and nothing referenced the file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,8 @@ The gate is scoped to production dependencies on purpose. CI still prints a full
 
 Pre-commit hooks (Husky + lint-staged) run ESLint, Stylelint, and Prettier on staged files. If they fail, fix the reported issues and commit again.
 
+Branch from `develop` and target `develop`; `main` is the released mirror. Dependency PRs mostly look after themselves: patch and minor bumps from Dependabot, and the biweekly `npm update` PR, auto-merge once `lint-and-test (22.x)` passes. Major-version bumps stay open and need a human to review the breaking changes.
+
 ## Code style
 
 - **JavaScript:** ES2020+. Strict equality (`===`). Single quotes. camelCase. JSDoc on non-trivial functions. Rules live in `eslint.config.js`.

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ Use this when you want a small, framework-free static site or web app and you do
 ## Quick start
 
 ```bash
-npx degit marcop135/vite-vanilla-sass-lint my-app
+npx degit marcop135/vite-vanilla-sass-lint#main my-app
 cd my-app
 npm install
 npm run dev
 ```
 
 Dev server runs on `http://localhost:3000`.
+
+`main` is the released mirror, tagged at every version. `develop` is the default and integration branch, where dependency updates land first; scaffold from it by dropping the `#main` suffix.
 
 ## What's included
 
@@ -29,25 +31,25 @@ Dev server runs on `http://localhost:3000`.
 
 ## Scripts
 
-| Command                 | What it does                                                  |
-| ----------------------- | ------------------------------------------------------------- |
-| `npm run dev`           | Start Vite dev server                                         |
-| `npm run build`         | Production build to `dist/`                                   |
-| `npm run preview`       | Serve the production build locally                            |
-| `npm run lint`          | ESLint + Stylelint + HTMLHint + html-validate                 |
-| `npm run lint:fix`      | Same, auto-fixing what's fixable                              |
-| `npm run format`        | Prettier write across `src/**` and root `index.html`          |
-| `npm run format:check`  | Prettier check (no writes)                                    |
-| `npm run test`          | Vitest watch                                                  |
-| `npm run test:ci`       | Vitest single run                                             |
-| `npm run test:ui`       | Vitest UI                                                     |
-| `npm run test:coverage` | Vitest coverage report                                        |
-| `npm run analyze`       | Build with bundle visualizer, opens `dist/stats.html`         |
-| `npm run audit`         | `npm audit` across the full tree (dev included)               |
-| `npm run audit:prod`    | `npm audit --omit=dev --audit-level=moderate`                 |
-| `npm run audit:fix`     | `npm audit fix`                                               |
-| `npm run release:check` | Same gates as CI: lint, format, test, build, `audit:prod`     |
-| `npm run clean`         | Remove `dist/`                                                |
+| Command                 | What it does                                              |
+| ----------------------- | --------------------------------------------------------- |
+| `npm run dev`           | Start Vite dev server                                     |
+| `npm run build`         | Production build to `dist/`                               |
+| `npm run preview`       | Serve the production build locally                        |
+| `npm run lint`          | ESLint + Stylelint + HTMLHint + html-validate             |
+| `npm run lint:fix`      | Same, auto-fixing what's fixable                          |
+| `npm run format`        | Prettier write across `src/**` and root `index.html`      |
+| `npm run format:check`  | Prettier check (no writes)                                |
+| `npm run test`          | Vitest watch                                              |
+| `npm run test:ci`       | Vitest single run                                         |
+| `npm run test:ui`       | Vitest UI                                                 |
+| `npm run test:coverage` | Vitest coverage report                                    |
+| `npm run analyze`       | Build with bundle visualizer, opens `dist/stats.html`     |
+| `npm run audit`         | `npm audit` across the full tree (dev included)           |
+| `npm run audit:prod`    | `npm audit --omit=dev --audit-level=moderate`             |
+| `npm run audit:fix`     | `npm audit fix`                                           |
+| `npm run release:check` | Same gates as CI: lint, format, test, build, `audit:prod` |
+| `npm run clean`         | Remove `dist/`                                            |
 
 ## Project layout
 
@@ -84,7 +86,11 @@ Production build emits ESM only and uses `sourcemap: 'hidden'`: maps are produce
 
 Changes land on `develop`, then a release commit (`chore(release): X.Y.Z`) merges to `develop`, the merge is tagged `vX.Y.Z`, and `main` is merged up from `develop`. The `release.yml` workflow then runs `release:check` against the tag and publishes a GitHub Release whose body is built from `CHANGELOG.md` by `scripts/release-notes-from-changelog.mjs`.
 
-A scheduled workflow (`scheduled-patch-release.yml`) runs the bump, PR, merge, tag, and `main` sync biweekly on the 3rd and 17th UTC. The sync merges rather than fast-forwards, so a commit that lands on `main` alone (Dependabot security PRs target the default branch) cannot wedge the pipeline. See [`CHANGELOG.md`](./CHANGELOG.md) for the full history.
+A scheduled workflow (`scheduled-patch-release.yml`) runs the bump, PR, merge, tag, and `main` sync biweekly on the 3rd and 17th UTC. The sync merges rather than fast-forwards, so a commit that lands on `main` alone cannot wedge the pipeline. See [`CHANGELOG.md`](./CHANGELOG.md) for the full history.
+
+### Dependency updates
+
+Dependabot opens weekly version and security PRs against `develop`. `dependabot-auto-merge.yml` squash-merges patch and minor updates once `lint-and-test (22.x)` passes; major-version bumps are left open for review. A second workflow (`scheduled-npm-update.yml`) runs `npm update` on the 1st and 15th UTC, verifies it with `release:check`, and opens a PR that auto-merges on the same required check, two days before the release job runs.
 
 ### Audit gate
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-vanilla-sass-lint",
-  "version": "1.10.8",
+  "version": "1.10.9",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Why

Two gaps forced manual work on every dependency cycle.

**The biweekly `npm update` PR was opened and never merged.** `scheduled-npm-update.yml` runs on the 1st and 15th, verifies with `release:check`, and opens a PR into `develop`. Nothing merged it. `scheduled-patch-release.yml` fires on the 3rd and 17th on the assumption those PRs "have time to land" (its own header comment), so unless someone merged by hand the release shipped without them and the PR sat open.

**Dependabot security PRs landed on `main`, where no workflow touches them.** `dependabot.yml` set `target-branch: 'develop'`, and GitHub disables security updates for any ecosystem config that sets it, so security PRs fell back to the default branch. `dependabot-auto-merge.yml` only listens on `develop`, and `main` has no branch protection. This was already recorded as a known hole in `AGENTS.md`.

## What changed

1. **Auto-merge on the `npm update` PR.** New `Enable auto-merge` step in `scheduled-npm-update.yml` using `RELEASE_PAT`, matching the token that opened the PR and the pattern in `scheduled-patch-release.yml`. `develop` is protected with `lint-and-test (22.x)` required and strict mode on, so `--auto` queues behind CI rather than merging on the spot. The `pull-request-operation` guard skips no-op runs, where `npm update` changes nothing and no PR is opened.
2. **Security PR routing.** `target-branch` dropped from both `dependabot.yml` entries, with a comment on why it must not come back. Paired with the default branch moving to `develop`, version and security PRs both land on `develop` and flow through the existing auto-merge and release chain. Nothing in `release.yml` or `scheduled-patch-release.yml` reads the default branch; every ref there is explicit.
3. **Docs.** Dependency intake documented in `README.md` (new "Dependency updates" subsection), `AGENTS.md` (git rules rewritten for the new default branch), and `CONTRIBUTING.md`. The degit quick start is pinned to `#main` so scaffolding still comes off the released mirror.
4. **Changelog + version** bumped to 1.10.9.

## Follow-up required after merge

One repo setting change, which must happen **after** this merges, never before:

```
gh api -X PATCH repos/marcop135/vite-vanilla-sass-lint -f default_branch=develop
```

Between dropping `target-branch` and flipping the default, Dependabot would briefly target `main`.

## Verification

- `npm run release:check` -> lint, format check, 7/7 tests, build, `audit:prod` (0 vulnerabilities)
- `node scripts/release-notes-from-changelog.mjs v1.10.9 out.md` renders the 1.10.9 section cleanly
- Both edited YAML files parse; `scheduled-npm-update.yml` job steps resolve in order with `Enable auto-merge` last
